### PR TITLE
Update hashie dependency from 2.1 to 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
   - "1.9.3-p551"
-  - "2.0.0-p598"
-  - "2.1.6"
-  - "2.2.2"
+  - "2.0.0-p647"
+  - "2.1.7"
+  - "2.2.3"
 install: bundle install --binstubs
 env: TRAVIS_BUILD=true
 matrix:

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Changelog for chef-vault-testfixtures
 
+## 0.5.1
+
+* update dependency on hashie from 2.1 to 3.4
+
 ## 0.5.0
 
 * breaking change: by default, only stub calls to `ChefVault::Item.load(bag, item)` and `Chef::DataBag.load(bag).key?(item_keys)`.  This allows people who are using the JSON files in test/integration/data_bags to stub unencrypted data bag to do so.  See the README for details of how to continue to stub `ChefVault::DataBagItem.load(bag, item)` and return a fake hash.  Reported by [Dru Goradia](https://github.com/dgoradia-atlas))

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
     license 'apache2'
     extra_deps << ['rspec', '~> 3.1']
     extra_deps << ['chef-vault', '~> 2.5']
-    extra_deps << ['hashie', '~> 2.1']
+    extra_deps << ['hashie', '~> 3.4']
     extra_dev_deps << ['chef', '~> 12.0']
     extra_dev_deps << ['hoe', '~> 3.13']
     extra_dev_deps << ['hoe-gemspec', '~> 1.0']

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 * provide mechanism for limiting which vaults are loaded
 * provide mechanism to clear singleton
 * eventually, integrate into the chef-vault gem
+* fix rubocop warnings about nested definitions

--- a/chef-vault-testfixtures.gemspec
+++ b/chef-vault-testfixtures.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-vault-testfixtures 0.5.0.20151029165221 ruby lib
+# stub: chef-vault-testfixtures 0.5.0.20151029171447 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-vault-testfixtures"
-  s.version = "0.5.0.20151029165221"
+  s.version = "0.5.0.20151029171447"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-10-29"
+  s.date = "2015-10-30"
   s.description = "chef-vault-testfixtures provides an RSpec shared context that\nstubs access to chef-vault encrypted data bags using the same\nfallback mechanism as the `chef_vault_item` helper from the\n[chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)"
   s.email = ["james.i.fitzgibbon@nordstrom.com"]
   s.extra_rdoc_files = ["History.md", "Manifest.txt", "README.md"]

--- a/chef-vault-testfixtures.gemspec
+++ b/chef-vault-testfixtures.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-vault-testfixtures 0.4.2.20150505160823 ruby lib
+# stub: chef-vault-testfixtures 0.5.0.20151029165221 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-vault-testfixtures"
-  s.version = "0.4.2.20150505160823"
+  s.version = "0.5.0.20151029165221"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-05-05"
+  s.date = "2015-10-29"
   s.description = "chef-vault-testfixtures provides an RSpec shared context that\nstubs access to chef-vault encrypted data bags using the same\nfallback mechanism as the `chef_vault_item` helper from the\n[chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)"
   s.email = ["james.i.fitzgibbon@nordstrom.com"]
   s.extra_rdoc_files = ["History.md", "Manifest.txt", "README.md"]
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/Nordstrom/chef-vault-testfixtures"
   s.licenses = ["apache2"]
   s.rdoc_options = ["--main", "README.md"]
-  s.rubygems_version = "2.4.4"
+  s.rubygems_version = "2.4.5.1"
   s.summary = "chef-vault-testfixtures provides an RSpec shared context that stubs access to chef-vault encrypted data bags using the same fallback mechanism as the `chef_vault_item` helper from the [chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)"
 
   if s.respond_to? :specification_version then
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rspec>, ["~> 3.1"])
       s.add_runtime_dependency(%q<chef-vault>, ["~> 2.5"])
-      s.add_runtime_dependency(%q<hashie>, ["~> 2.1"])
+      s.add_runtime_dependency(%q<hashie>, ["~> 3.4"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<chef>, ["~> 12.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<rspec>, ["~> 3.1"])
       s.add_dependency(%q<chef-vault>, ["~> 2.5"])
-      s.add_dependency(%q<hashie>, ["~> 2.1"])
+      s.add_dependency(%q<hashie>, ["~> 3.4"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<chef>, ["~> 12.0"])
       s.add_dependency(%q<hoe>, ["~> 3.13"])
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<rspec>, ["~> 3.1"])
     s.add_dependency(%q<chef-vault>, ["~> 2.5"])
-    s.add_dependency(%q<hashie>, ["~> 2.1"])
+    s.add_dependency(%q<hashie>, ["~> 3.4"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<chef>, ["~> 12.0"])
     s.add_dependency(%q<hoe>, ["~> 3.13"])

--- a/lib/chef-vault/test_fixtures.rb
+++ b/lib/chef-vault/test_fixtures.rb
@@ -11,7 +11,7 @@ class ChefVault
   # dynamic RSpec contexts for cookbooks that use chef-vault
   class TestFixtures
     # the version of the gem
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
 
     # dynamically creates a memoized RSpec shared context
     # that when included into an example group will stub


### PR DESCRIPTION
See #14 for a little bit of context.

My Ruby-fu is not strong enough to really know whether naively changing the hashie dependency breaks anything, but the tests pass.

Furthermore, my attempts to make my test environment think it was going to build a gem with a version 0.5.1 came to naught - see honest assessment of Ruby-fu above.
