### PR TITLE
Fix Gem::ConflictError with hashie gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: ruby
 rvm:
-  - "1.9.3-p551"
-  - "2.0.0-p598"
   - "2.1.6"
   - "2.2.2"
 install: bundle install --binstubs
 env: TRAVIS_BUILD=true
-matrix:
-  allow_failures:
-    - rvm: "1.9.3-p551"

--- a/History.md
+++ b/History.md
@@ -1,5 +1,14 @@
 # Changelog for chef-vault-testfixtures
 
+## 0.5.1
+
+* Update `hashie` gem dependency to ~> 3.4 to avoid Gem::ConflictError with hashie 3.4.3 installed by ChefDK 0.10.0
+
+```
+`raise_if_conflicts': Unable to activate chef-vault-testfixtures-0.5.0,
+because hashie-3.4.3 conflicts with hashie (~> 2.1) (Gem::ConflictError)
+```
+
 ## 0.5.0
 
 * breaking change: by default, only stub calls to `ChefVault::Item.load(bag, item)` and `Chef::DataBag.load(bag).key?(item_keys)`.  This allows people who are using the JSON files in test/integration/data_bags to stub unencrypted data bag to do so.  See the README for details of how to continue to stub `ChefVault::DataBagItem.load(bag, item)` and return a fake hash.  Reported by [Dru Goradia](https://github.com/dgoradia-atlas))

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
     license 'apache2'
     extra_deps << ['rspec', '~> 3.1']
     extra_deps << ['chef-vault', '~> 2.5']
-    extra_deps << ['hashie', '~> 2.1']
+    extra_deps << ['hashie', '~> 3.4']
     extra_dev_deps << ['chef', '~> 12.0']
     extra_dev_deps << ['hoe', '~> 3.13']
     extra_dev_deps << ['hoe-gemspec', '~> 1.0']
@@ -23,7 +23,7 @@ begin
     extra_dev_deps << ['guard-rake', '~> 0.0']
     extra_dev_deps << ['guard-rubocop', '~> 1.2']
     extra_dev_deps << ['chefspec', '~> 4.2']
-    extra_dev_deps << ['berkshelf', '~> 3.2']
+    extra_dev_deps << ['berkshelf', '~> 4.0']
     extra_dev_deps << ['rubocop', '~> 0.29']
     extra_dev_deps << ['simplecov', '~> 0.9']
     extra_dev_deps << ['simplecov-console', '~> 0.2']

--- a/chef-vault-testfixtures.gemspec
+++ b/chef-vault-testfixtures.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-vault-testfixtures 0.4.2.20150505160823 ruby lib
+# stub: chef-vault-testfixtures 0.5.1.20160203174822 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-vault-testfixtures"
-  s.version = "0.4.2.20150505160823"
+  s.version = "0.5.1.20160203174822"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-05-05"
+  s.date = "2016-02-04"
   s.description = "chef-vault-testfixtures provides an RSpec shared context that\nstubs access to chef-vault encrypted data bags using the same\nfallback mechanism as the `chef_vault_item` helper from the\n[chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)"
   s.email = ["james.i.fitzgibbon@nordstrom.com"]
   s.extra_rdoc_files = ["History.md", "Manifest.txt", "README.md"]
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/Nordstrom/chef-vault-testfixtures"
   s.licenses = ["apache2"]
   s.rdoc_options = ["--main", "README.md"]
-  s.rubygems_version = "2.4.4"
+  s.rubygems_version = "2.4.8"
   s.summary = "chef-vault-testfixtures provides an RSpec shared context that stubs access to chef-vault encrypted data bags using the same fallback mechanism as the `chef_vault_item` helper from the [chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)"
 
   if s.respond_to? :specification_version then
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rspec>, ["~> 3.1"])
       s.add_runtime_dependency(%q<chef-vault>, ["~> 2.5"])
-      s.add_runtime_dependency(%q<hashie>, ["~> 2.1"])
+      s.add_runtime_dependency(%q<hashie>, ["~> 3.4"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<chef>, ["~> 12.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<guard-rake>, ["~> 0.0"])
       s.add_development_dependency(%q<guard-rubocop>, ["~> 1.2"])
       s.add_development_dependency(%q<chefspec>, ["~> 4.2"])
-      s.add_development_dependency(%q<berkshelf>, ["~> 3.2"])
+      s.add_development_dependency(%q<berkshelf>, ["~> 4.0"])
       s.add_development_dependency(%q<rubocop>, ["~> 0.29"])
       s.add_development_dependency(%q<simplecov>, ["~> 0.9"])
       s.add_development_dependency(%q<simplecov-console>, ["~> 0.2"])
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<rspec>, ["~> 3.1"])
       s.add_dependency(%q<chef-vault>, ["~> 2.5"])
-      s.add_dependency(%q<hashie>, ["~> 2.1"])
+      s.add_dependency(%q<hashie>, ["~> 3.4"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<chef>, ["~> 12.0"])
       s.add_dependency(%q<hoe>, ["~> 3.13"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<guard-rake>, ["~> 0.0"])
       s.add_dependency(%q<guard-rubocop>, ["~> 1.2"])
       s.add_dependency(%q<chefspec>, ["~> 4.2"])
-      s.add_dependency(%q<berkshelf>, ["~> 3.2"])
+      s.add_dependency(%q<berkshelf>, ["~> 4.0"])
       s.add_dependency(%q<rubocop>, ["~> 0.29"])
       s.add_dependency(%q<simplecov>, ["~> 0.9"])
       s.add_dependency(%q<simplecov-console>, ["~> 0.2"])
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<rspec>, ["~> 3.1"])
     s.add_dependency(%q<chef-vault>, ["~> 2.5"])
-    s.add_dependency(%q<hashie>, ["~> 2.1"])
+    s.add_dependency(%q<hashie>, ["~> 3.4"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<chef>, ["~> 12.0"])
     s.add_dependency(%q<hoe>, ["~> 3.13"])
@@ -75,7 +75,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<guard-rake>, ["~> 0.0"])
     s.add_dependency(%q<guard-rubocop>, ["~> 1.2"])
     s.add_dependency(%q<chefspec>, ["~> 4.2"])
-    s.add_dependency(%q<berkshelf>, ["~> 3.2"])
+    s.add_dependency(%q<berkshelf>, ["~> 4.0"])
     s.add_dependency(%q<rubocop>, ["~> 0.29"])
     s.add_dependency(%q<simplecov>, ["~> 0.9"])
     s.add_dependency(%q<simplecov-console>, ["~> 0.2"])

--- a/lib/chef-vault/test_fixtures.rb
+++ b/lib/chef-vault/test_fixtures.rb
@@ -11,7 +11,7 @@ class ChefVault
   # dynamic RSpec contexts for cookbooks that use chef-vault
   class TestFixtures
     # the version of the gem
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
 
     # dynamically creates a memoized RSpec shared context
     # that when included into an example group will stub


### PR DESCRIPTION
Update `hashie` gem dependency to ~> 3.4 to avoid Gem::ConflictError with hashie 3.4.3 installed by ChefDK 0.10.0