### PR TITLE
Fixed typo to prevent "undefined method"-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The recipe that the example tests:
     include_recipe 'chef-vault'
     item = chef_vault_item('foo', 'bar')
     file '/tmp/foo' do
-      contents item['password']
+      content item['password']
     end
 
 The helper will call `ChefVault::Item.load`, which will be stubbed using


### PR DESCRIPTION
The usage example in the readme.md causes an "undefined method" error. This PR fixes the typo.

```
       Running handlers:
       [2018-01-27T14:26:40+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2018-01-27T14:26:40+00:00] ERROR: Exception handlers complete
       Chef Client failed. 0 resources updated in 08 seconds
       [2018-01-27T14:26:40+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2018-01-27T14:26:40+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2018-01-27T14:26:40+00:00] ERROR: undefined method `contents' for Chef::Resource::File
       [2018-01-27T14:26:40+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```