### PR TITLE
Require Ruby 2.5+ / allow for chef-vault 4.x

### DIFF
--- a/chef-vault-testfixtures.gemspec
+++ b/chef-vault-testfixtures.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.rdoc_options              = ["--main", "README.md"]
   s.summary                   = "chef-vault-testfixtures provides an RSpec shared context that stubs access to chef-vault encrypted data bags using the same fallback mechanism as the `chef_vault_item` helper from the [chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)"
   s.description               = s.summary
-  s.required_ruby_version     = ">= 2.2.0"
+  s.required_ruby_version     = ">= 2.5"
 
   s.add_runtime_dependency       "rspec", "~> 3.4"
-  s.add_runtime_dependency       "chef-vault", "~> 3"
+  s.add_runtime_dependency       "chef-vault", ">= 3", "< 5" # validate 5 if we release that
   s.add_runtime_dependency       "hashie", "< 4.0", ">= 2.0"
 end


### PR DESCRIPTION
Only support versions of Ruby that are supported and work with the latest chef-vault\

Signed-off-by: Tim Smith <tsmith@chef.io>